### PR TITLE
docs: add AGENTS.md with PR-only workflow policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@
 - Stop after creating the PR and wait for user approval before any merge.
 - If a merge is explicitly requested, reconfirm once before merging.
 
+## GitHub Auth (Mandatory)
+- If GitHub CLI or git HTTPS auth fails, ask the user for a one-time `GH_TOKEN` and proceed with that token.
+- Use the token only as an environment variable for the current command/session (do not store it in files or git config).
+- After push/PR/issue operations are done, treat the token as expired and ask again next time if needed.
+
 ## Default Delivery Style
 - Prefer small, reviewable commits.
 - Include clear test steps in PR description.


### PR DESCRIPTION
## Summary
- add repository-level AGENTS.md
- define mandatory PR-only workflow (no direct merge to main)
- require user approval before merge

## Test
- docs-only change
